### PR TITLE
Bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,11 +81,11 @@ function normalize(dep, options) {
     return res;
 }
 
-module.exports = function (deps) {
+module.exports = function (deps, options) {
     if (!deps) { return []; }
     if (!Array.isArray(deps)) { deps = [ deps ]; }
 
     return deps.reduce(function (previous, current) {
-        return previous.concat(normalize(current));
+        return previous.concat(normalize(current, options));
     }, []);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -5,12 +5,9 @@ require('should');
 
 describe('constructor', function () {
     it('should support custom string parsing', function () {
-        it('should support string', function () {
-            nomralize('jquery', {parseString: function (dep) {
-                return { block: 'custom', elem: dep };
-            }})
-            .should.eql([{ block: 'custom', elem: 'jquery' }]);
-        });
+        nomralize('jquery', {parseString: function (dep) {
+            return { block: 'custom', elem: dep };
+        }}).should.eql([{ block: 'custom', elem: 'jquery' }]);
     });
 
     it('should throw expection on empty object', function () {


### PR DESCRIPTION
Parse-test worked incorrectly, because 'it' inside of 'it' always returned pass: code worked only in first 'it', second 'it' just don't launched. It was reason for invisible options bug.