### PR TITLE
Skipping empty elems and mods

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ function normalize(dep, options) {
 
     if (dep.elems) {
         dep.elems.forEach(function(elem) {
+            if (elem === '') return;
+
             res.push(extend({ elem: elem }, dep));
         });
     }
@@ -59,6 +61,8 @@ function normalize(dep, options) {
     if (dep.mods) {
         if (Array.isArray(dep.mods)) {
             dep.mods.forEach(function(mod) {
+                if (mod === '') return;
+
                 res.push(extend({ modName: mod }, dep));
             });
         } else {

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,14 @@ describe('constructor', function () {
         nomralize(undefined).should.be.eql([]);
     });
 
+    it("shouldn't return empty elems", function () {
+        nomralize({ elems: [''] }).should.eql([]);
+    });
+
+    it("shouldn't return empty mods", function () {
+        nomralize({ mods: [''] }).should.eql([]);
+    });
+
     it('should wrap objects into array', function () {
         var obj = {block: 'block'};
         nomralize(obj).should.eql([obj]);


### PR DESCRIPTION
In my opinion empty elements should be ignored:
`{ elems: [''] }` => [].
